### PR TITLE
[fix]: deprecated imresize function

### DIFF
--- a/moby_eye_tracking.py
+++ b/moby_eye_tracking.py
@@ -9,7 +9,7 @@ import sys
 import matplotlib.pyplot as plt 
 import numpy as np
 
-from scipy.misc import imresize
+from skimage.transform import resize as imresize
 
 from tkinter import *
 

--- a/moby_eye_tracking.py
+++ b/moby_eye_tracking.py
@@ -94,6 +94,8 @@ def extract_facial_features(frame, downsample=0.5, get_gradients=True, display=F
     
     # Basic code for facial landmark extraction from webcam from:
     # https://elbruno.com/2019/05/29/vscode-lets-do-some-facerecognition-with-20-lines-in-python-3-n/    
+    downsample = (int(frame.shape[1]*0.5), int(frame.shape[0]*0.5))
+  
     try:
         rgb_frame = frame[:, :, ::-1].copy()
         rgb_frame_copy = frame[:, :, ::-1].copy()


### PR DESCRIPTION
`imresize` has been deprecated from `scipy 1.3` and later versions, so this code won't work with the current versions of required libraries and frameworks.

I have fixed this by using `resize` function from `skimage` library which has the same signature as `imresize`. It needs `skimage` to be installed. `pip install skimage`.